### PR TITLE
Remove unused "thread" import

### DIFF
--- a/aplus/__init__.py
+++ b/aplus/__init__.py
@@ -337,8 +337,6 @@ class BackgroundThread(Thread):
             self.promise.reject(str(e))
 
 def background(f):
-    import thread
-
     p = Promise()
     t = BackgroundThread(p, f)
     t.start()


### PR DESCRIPTION
Unfortunately, "import thread" doesn't work in Python 3. Fortunately, it's not being used in this function anyway, which means that it _should_ be fine to just remove it. (I put this in a branch _just in case_ it needed to be there for some reason I was missing.)
