### PR TITLE
Change .then to comply with section 2.2.7.2 of the A+ specification:

### DIFF
--- a/aplus/__init__.py
+++ b/aplus/__init__.py
@@ -165,7 +165,7 @@ class Promise:
                 else:
                     pass
             except Exception as e:
-                ret.reject(str(e))
+                ret.reject(e)
 
         def callAndReject(r):
             """
@@ -186,7 +186,7 @@ class Promise:
                 else:
                     pass
             except Exception as e:
-                ret.reject(str(e))
+                ret.reject(e)
         
         if self._state==self.PENDING:
             """
@@ -221,7 +221,7 @@ class Promise:
                 else:
                     pass
             except Exception as e:
-                ret.reject(str(e))
+                ret.reject(e)
         elif self._state==self.REJECTED:
             """
             If this promise was already rejected, then
@@ -243,7 +243,7 @@ class Promise:
                 else:
                     pass
             except Exception as e:
-                ret.reject(str(e))
+                ret.reject(e)
 
         return ret
 
@@ -334,7 +334,7 @@ class BackgroundThread(Thread):
             val = self.func()
             self.promise.fulfill(val)
         except Exception as e:
-            self.promise.reject(str(e))
+            self.promise.reject(e)
 
 def background(f):
     p = Promise()
@@ -350,7 +350,7 @@ def spawn(f):
             val = f()
             p.fulfill(val)
         except Exception as e:
-            p.reject(str(e))
+            p.reject(e)
 
     p = Promise()
     g = spawn(lambda: process(p, f))

--- a/tests/TestExtraFeatures.py
+++ b/tests/TestExtraFeatures.py
@@ -196,7 +196,8 @@ def test_background():
     assert p1.isFulfilled()
     assert p2.isRejected()
     assert_equals(25, p1.value)
-    assert_equals("Something went wrong", p2.reason)
+    assert isinstance(p2.reason, ValueError)
+    assert_equals("Something went wrong", str(p2.reason))
 
 def test_spawn():
     import gevent
@@ -218,4 +219,5 @@ def test_spawn():
     assert p1.isFulfilled()
     assert p2.isRejected()
     assert_equals(25, p1.value)
-    assert_equals("Something went wrong", p2.reason)
+    assert isinstance(p2.reason, ValueError)
+    assert_equals("Something went wrong", str(p2.reason))

--- a/tests/TestSuite.py
+++ b/tests/TestSuite.py
@@ -266,13 +266,15 @@ def test_3_2_6_2_when():
     pf = p1.then(fail)
     p1.fulfill(5)
     assert pf.isRejected()
-    assert_equals("Exception Message", pf.reason)
+    assert isinstance(pf.reason, AssertionError)
+    assert_equals("Exception Message", str(pf.reason))
 
     p2 = Promise()
     pr = p2.then(None, fail)
     p2.reject("Error")
     assert pr.isRejected()
-    assert_equals("Exception Message", pr.reason)
+    assert isinstance(pr.reason, AssertionError)
+    assert_equals("Exception Message", str(pr.reason))
 
 def test_3_2_6_2_if():
     """
@@ -286,13 +288,15 @@ def test_3_2_6_2_if():
     p1.fulfill(5)
     pf = p1.then(fail)
     assert pf.isRejected()
-    assert_equals("Exception Message", pf.reason)
+    assert isinstance(pf.reason, AssertionError)
+    assert_equals("Exception Message", str(pf.reason))
 
     p2 = Promise()
     p2.reject("Error")
     pr = p2.then(None, fail)
     assert pr.isRejected()
-    assert_equals("Exception Message", pr.reason)
+    assert isinstance(pr.reason, AssertionError)
+    assert_equals("Exception Message", str(pr.reason))
 
 def test_3_2_6_3_when_fulfilled():
     """


### PR DESCRIPTION
if 'promise2 = promise1.then(onFulfilled, onRejected)' and 'either onFulfilled or onRejected throws an exception e, promise2 must be rejected with e as the reason'.  (Also changed the optional background process to reject promises with e instead of str(e), for consistency.)
